### PR TITLE
removed ifco transformation in scene file

### DIFF
--- a/model/rlsg/ifco.wrl
+++ b/model/rlsg/ifco.wrl
@@ -2,12 +2,12 @@
 
 Transform
   {
-  translation 0.84999996 0 -0.53544157
+  translation 0.0 0 -0.0
   children 
     Transform
       {
-      rotation 0 0 1 1.57079994
-      translation -0.25000000 0 0.64999997
+      rotation 0 0 0 1 
+      translation -0.0 0 0
       children 
 	[
 	DEF bottom Shape


### PR DESCRIPTION
removed ifco transformation in scene file (should be only provided by the ifco_pose service call argument)!

@ikrets I created this PR to let you now about it, since this change will also affect all examples in the example folder. They need to incorporate the old transformation that was contained in the scene file into their paramters.