### PR TITLE
More information on failure

### DIFF
--- a/model/rlsg/barrett-wam.convex/rbohand_kinematics_check.wrl
+++ b/model/rlsg/barrett-wam.convex/rbohand_kinematics_check.wrl
@@ -1,12 +1,12 @@
 #VRML V2.0 utf8
 
-DEF ScaffoldMount Transform
+Transform
   {
   rotation -0.5773503 -0.5773503 -0.5773503 2.0943951
   translation 0.003 0 0
   children 
     [
-    Shape
+    DEF Mount Shape
       {
       appearance Appearance
 	{
@@ -126,12 +126,12 @@ DEF ScaffoldMount Transform
 		}
 	      }
 	  }
-	DEF PalmScaffold Transform
+	Transform
 	  {
 	  rotation 3.71050275e-2 -4.75708320e-2 -0.99817848 2.14919710
 	  translation -2.96577271e-2 2.83292680e-2 1.25902623e-3
 	  children 
-	    Shape
+	    DEF PalmScaffold Shape
 	      {
 	      appearance Appearance
 		{
@@ -147,12 +147,12 @@ DEF ScaffoldMount Transform
 		}
 	      }
 	  }
-	DEF Palm1 Transform
+	Transform
 	  {
 	  rotation -0.34452247 0.10565368 -0.93281376 3.67458152
 	  translation -6.11586198e-2 3.23250074e-3 -6.13031117e-3
 	  children 
-	    Shape
+	    DEF Palm1 Shape
 	      {
 	      appearance Appearance
 		{
@@ -168,12 +168,12 @@ DEF ScaffoldMount Transform
 		}
 	      }
 	  }
-	DEF Thumb Transform
+	Transform
 	  {
 	  rotation -0.22141501 -0.11039344 0.96891105 0.95048576
 	  translation -7.47148469e-2 9.56771057e-3 -8.18631052e-2
 	  children 
-	    Shape
+	    DEF Thumb Shape
 	      {
 	      appearance Appearance
 		{
@@ -189,12 +189,12 @@ DEF ScaffoldMount Transform
 		}
 	      }
 	  }
-	DEF Palm2 Transform
+	Transform
 	  {
 	  rotation -0.62270116 0.18541179 -0.76017481 3.58329796
 	  translation -4.57854978e-2 -6.88831694e-3 1.28308068e-2
 	  children 
-	    Shape
+	    DEF Palm2 Shape
 	      {
 	      appearance Appearance
 		{
@@ -210,12 +210,12 @@ DEF ScaffoldMount Transform
 		}
 	      }
 	  }
-	DEF Palm3 Transform
+	Transform
 	  {
 	  rotation -0.62270116 0.18541179 -0.76017481 3.58329796
 	  translation -7.91772529e-2 1.49138579e-2 -2.91231293e-2
 	  children 
-	    Shape
+	    DEF Palm3 Shape
 	      {
 	      appearance Appearance
 		{

--- a/src/collision_types.cpp
+++ b/src/collision_types.cpp
@@ -1,5 +1,7 @@
 #include "collision_types.h"
 
+const std::string RequiredCollisionsCounter::EveryPartPlaceholder = "*";
+
 WorldCollisionTypes::WorldCollisionTypes(const WorldCollisionTypes::PartToCollisionType& world_part_to_collision_type)
   : world_part_to_collision_type_(world_part_to_collision_type)
 {
@@ -69,6 +71,12 @@ bool IgnoreAllCollisionTypes::IgnoreAllRequiredCollisionsCounter::allRequiredPre
   return true;
 }
 
+std::vector<std::pair<std::string, std::string>>
+IgnoreAllCollisionTypes::IgnoreAllRequiredCollisionsCounter::unseenRequiredCollisions() const
+{
+  return std::vector<std::pair<std::string, std::string>>();
+}
+
 void IgnoreAllCollisionTypes::IgnoreAllRequiredCollisionsCounter::countCollision(const std::string&, const std::string&)
 {
 }
@@ -83,4 +91,15 @@ bool CollisionType::valid()
     return !ignored && !terminating && !required;
 
   return true;
+}
+
+std::vector<std::pair<std::string, std::string>>
+WorldCollisionTypes::WorldRequiredCollisionsCounter::unseenRequiredCollisions() const
+{
+  std::vector<std::pair<std::string, std::string>> unseen;
+
+  for (auto& world_part : nonpresent_required_world_collisions_)
+    unseen.push_back({ EveryPartPlaceholder, world_part });
+
+  return unseen;
 }

--- a/src/collision_types.h
+++ b/src/collision_types.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <memory>
+#include <vector>
 
 /* Stores the type of collision constraint/requirement. A valid CollisionType is either prohibited, or allowed with all
  * possible combinations of ignored, terminating and required.
@@ -26,9 +27,14 @@ struct CollisionType
 class RequiredCollisionsCounter
 {
 public:
+  /* This string means "Every part". */
+  static const std::string EveryPartPlaceholder;
+
   virtual ~RequiredCollisionsCounter();
   /* If this counter have seen all required collisions. */
   virtual bool allRequiredPresent() const = 0;
+  /* Return a collection of still unseen required collisions, possibly having EveryPartPlaceholder as a part. */
+  virtual std::vector<std::pair<std::string, std::string>> unseenRequiredCollisions() const = 0;
   /* Count the collision between robot_part and world_part. */
   virtual void countCollision(const std::string& robot_part, const std::string& world_part) = 0;
 };
@@ -65,6 +71,7 @@ private:
     ~WorldRequiredCollisionsCounter() override;
 
     bool allRequiredPresent() const override;
+    std::vector<std::pair<std::string, std::string>> unseenRequiredCollisions() const override;
     void countCollision(const std::string& robot_part, const std::string& world_part) override;
 
   private:
@@ -91,6 +98,7 @@ private:
   {
   public:
     bool allRequiredPresent() const override;
+    std::vector<std::pair<std::string, std::string>> unseenRequiredCollisions() const override;
     void countCollision(const std::string& robot_part, const std::string& world_part) override;
   };
 };
@@ -108,6 +116,7 @@ private:
   public:
     ~IgnoreAllRequiredCollisionsCounter() override;
     bool allRequiredPresent() const override;
+    std::vector<std::pair<std::string, std::string>> unseenRequiredCollisions() const override;
     void countCollision(const std::string& robot_part, const std::string& world_part) override;
   };
 };

--- a/src/jacobian_controller.cpp
+++ b/src/jacobian_controller.cpp
@@ -1,7 +1,20 @@
 #include <rl/plan/Particle.h>
-#include "jacobian_controller.h"
 #include <iostream>
 #include <fstream>
+#include "jacobian_controller.h"
+#include "utilities.h"
+
+std::vector<unsigned> getJointsOverLimits(const rl::kin::Kinematics& kinematics, const rl::math::Vector& config)
+{
+  assert(kinematics.getDof() == config.size());
+
+  std::vector<unsigned> joints_over_limits;
+  for (std::size_t i = 0; i < config.size(); ++i)
+    if (config(i) < kinematics.getMinimum(i) || config(i) > kinematics.getMaximum(i))
+      joints_over_limits.push_back(i);
+
+  return joints_over_limits;
+}
 
 JacobianController::SingleResult::operator bool() const
 {
@@ -11,59 +24,27 @@ JacobianController::SingleResult::operator bool() const
   if (outcomes.size() != 1)
     return false;
 
-  Outcome outcome = *outcomes.begin();
+  Outcome outcome = outcomes.begin()->first;
 
   // REACHED and ACCEPTABLE_COLLISION are the only positive outcomes.
   return outcome == SingleResult::Outcome::REACHED || outcome == SingleResult::Outcome::ACCEPTABLE_COLLISION;
 }
 
-std::string JacobianController::SingleResult::description() const
-{
-  auto describeOutcome = [](Outcome outcome) {
-    switch (outcome)
-    {
-      case SingleResult::Outcome::REACHED:
-        return "reached the goal frame";
-      case SingleResult::Outcome::JOINT_LIMIT:
-        return "violated the joint limit";
-      case SingleResult::Outcome::SINGULARITY:
-        return "ended in the singularity";
-      case SingleResult::Outcome::STEPS_LIMIT:
-        return "went over the steps limit";
-      case SingleResult::Outcome::ACCEPTABLE_COLLISION:
-        return "ended on acceptable collision";
-      case SingleResult::Outcome::UNACCEPTABLE_COLLISION:
-        return "ended on unacceptable collision";
-      case SingleResult::Outcome::UNSENSORIZED_COLLISION:
-        return "ended on unsensorized collision";
-      case SingleResult::Outcome::MISSED_REQUIRED_COLLISIONS:
-        return "missing required collisions";
-      default:
-        assert(false);
-    }
-  };
-
-  std::stringstream ss;
-  bool first = true;
-  for (auto o : outcomes)
-  {
-    if (!first)
-      ss << ", ";
-    else
-      first = false;
-
-    ss << describeOutcome(o);
-  }
-
-  return ss.str();
-}
-
-JacobianController::SingleResult&
-JacobianController::SingleResult::setSingleOutcome(JacobianController::SingleResult::Outcome single_outcome)
+JacobianController::SingleResult& JacobianController::SingleResult::setSingleOutcome(
+    JacobianController::SingleResult::Outcome single_outcome,
+    JacobianController::SingleResult::OutcomeInformation outcome_information)
 {
   outcomes.clear();
-  outcomes.insert(single_outcome);
+  outcomes.insert({ single_outcome, outcome_information });
 
+  return *this;
+}
+
+JacobianController::SingleResult& JacobianController::SingleResult::addSingleOutcome(
+    JacobianController::SingleResult::Outcome outcome,
+    JacobianController::SingleResult::OutcomeInformation outcome_information)
+{
+  outcomes.insert({ outcome, outcome_information });
   return *this;
 }
 
@@ -116,11 +97,16 @@ JacobianController::SingleResult JacobianController::moveSingleParticle(const rl
 
     // arrived at the target pose
     if (q_dot.isZero())
+    {
       // if there were no required collisions at the start, or all of them were seen during the execution,
       // then it's a succesful termination
-      return result.setSingleOutcome(required_counter->allRequiredPresent() ?
-                                         SingleResult::Outcome::REACHED :
-                                         SingleResult::Outcome::MISSED_REQUIRED_COLLISIONS);
+      if (required_counter->allRequiredPresent())
+        return result.setSingleOutcome(SingleResult::Outcome::REACHED);
+      else
+        return result.setSingleOutcome(
+            SingleResult::Outcome::MISSED_REQUIRED_COLLISIONS,
+            SingleResult::OutcomeInformation::CollisionInformation(required_counter->unseenRequiredCollisions()));
+    }
 
     current_config += q_dot;
 
@@ -128,7 +114,9 @@ JacobianController::SingleResult JacobianController::moveSingleParticle(const rl
     emit drawConfiguration(current_config);
 
     if (!noisy_model_.isValid(current_config))
-      result.outcomes.insert(SingleResult::Outcome::JOINT_LIMIT);
+      result.addSingleOutcome(
+          SingleResult::Outcome::JOINT_LIMIT,
+          SingleResult::OutcomeInformation::JointNumbers(getJointsOverLimits(*kinematics_, current_config)));
 
     noisy_model_.setPosition(current_config);
     noisy_model_.updateFrames();
@@ -137,7 +125,7 @@ JacobianController::SingleResult JacobianController::moveSingleParticle(const rl
     noisy_model_.isColliding();
 
     if (noisy_model_.getDof() > 3 && noisy_model_.getManipulabilityMeasure() < 1.0e-3)
-      result.outcomes.insert(SingleResult::Outcome::SINGULARITY);
+      result.addSingleOutcome(SingleResult::Outcome::SINGULARITY);
 
     auto collision_constraints_check =
         checkCollisionConstraints(noisy_model_.scene->getLastCollisions(), collision_types, *required_counter);
@@ -147,11 +135,12 @@ JacobianController::SingleResult JacobianController::moveSingleParticle(const rl
 
     if (!result.outcomes.empty())
       return result;
-
     // success termination means that a terminating collision was seen, and all other collision constraints
     // and requirements were obeyed
     else if (collision_constraints_check.success_termination)
-      return result.setSingleOutcome(SingleResult::Outcome::ACCEPTABLE_COLLISION);
+      return result.setSingleOutcome(SingleResult::Outcome::ACCEPTABLE_COLLISION,
+                                     SingleResult::OutcomeInformation::CollisionInformation(
+                                         collision_constraints_check.seen_terminating_collisions));
   }
 
   return result.setSingleOutcome(SingleResult::Outcome::STEPS_LIMIT);
@@ -213,7 +202,9 @@ JacobianController::BeliefResult JacobianController::moveBelief(const rl::math::
       current_error += noise;
 
       if (!noisy_model_.isValid(current_config))
-        particle_result.outcomes.insert(SingleResult::Outcome::JOINT_LIMIT);
+        particle_result.addSingleOutcome(
+            SingleResult::Outcome::JOINT_LIMIT,
+            SingleResult::OutcomeInformation::JointNumbers(getJointsOverLimits(*kinematics_, current_config)));
 
       noisy_model_.setPosition(current_config);
       noisy_model_.updateFrames();
@@ -222,7 +213,7 @@ JacobianController::BeliefResult JacobianController::moveBelief(const rl::math::
       noisy_model_.isColliding();
 
       if (noisy_model_.getDof() > 3 && noisy_model_.getManipulabilityMeasure() < 1.0e-3)
-        particle_result.outcomes.insert(SingleResult::Outcome::SINGULARITY);
+        particle_result.addSingleOutcome(SingleResult::Outcome::SINGULARITY);
 
       auto collision_constraints_check =
           checkCollisionConstraints(noisy_model_.scene->getLastCollisions(), collision_types, *required_counter);
@@ -236,7 +227,9 @@ JacobianController::BeliefResult JacobianController::moveBelief(const rl::math::
       // a terminating collision was seen and all other constraints were obeyed
       if (collision_constraints_check.success_termination)
       {
-        particle_result.setSingleOutcome(SingleResult::Outcome::ACCEPTABLE_COLLISION);
+        particle_result.setSingleOutcome(SingleResult::Outcome::ACCEPTABLE_COLLISION,
+                                         SingleResult::OutcomeInformation::CollisionInformation(
+                                             collision_constraints_check.seen_terminating_collisions));
         break;
       }
     }
@@ -296,14 +289,17 @@ JacobianController::CollisionConstraintsCheck JacobianController::checkCollision
 
     // if the collision pair is ignored, touching with an unsensorized part is not a failure
     if (!isSensorized(shapes_in_contact.first) && !collision_type.ignored)
-      check.failures.insert(SingleResult::Outcome::UNSENSORIZED_COLLISION);
+      check.failures[SingleResult::Outcome::UNSENSORIZED_COLLISION].collisions.push_back(shapes_in_contact);
 
     required_counter.countCollision(shapes_in_contact.first, shapes_in_contact.second);
 
     if (collision_type.prohibited)
-      check.failures.insert(SingleResult::Outcome::UNACCEPTABLE_COLLISION);
+      check.failures[SingleResult::Outcome::UNACCEPTABLE_COLLISION].collisions.push_back(shapes_in_contact);
     if (collision_type.terminating)
+    {
       terminating_collision_present = true;
+      check.seen_terminating_collisions.push_back(shapes_in_contact);
+    }
   }
 
   // there was a terminating collision and there were no failures
@@ -313,7 +309,8 @@ JacobianController::CollisionConstraintsCheck JacobianController::checkCollision
     if (required_counter.allRequiredPresent())
       check.success_termination = true;
     else
-      check.failures.insert(SingleResult::Outcome::MISSED_REQUIRED_COLLISIONS);
+      check.failures[SingleResult::Outcome::MISSED_REQUIRED_COLLISIONS].collisions =
+          required_counter.unseenRequiredCollisions();
   }
 
   return check;
@@ -355,4 +352,21 @@ JacobianController::BeliefResult::operator bool() const
     return false;
 
   return std::all_of(particle_results->begin(), particle_results->end(), [](const SingleResult& r) { return r; });
+}
+
+JacobianController::SingleResult::OutcomeInformation
+JacobianController::SingleResult::OutcomeInformation::CollisionInformation(
+    std::vector<std::pair<std::string, std::string>> collisions)
+{
+  JacobianController::SingleResult::OutcomeInformation outcome_information;
+  outcome_information.collisions = collisions;
+  return outcome_information;
+}
+
+JacobianController::SingleResult::OutcomeInformation
+JacobianController::SingleResult::OutcomeInformation::JointNumbers(std::vector<unsigned> joint_indices)
+{
+  JacobianController::SingleResult::OutcomeInformation outcome_information;
+  outcome_information.joint_indices = joint_indices;
+  return outcome_information;
 }

--- a/src/jacobian_controller.h
+++ b/src/jacobian_controller.h
@@ -34,25 +34,38 @@ public:
       MISSED_REQUIRED_COLLISIONS
     };
 
+    /* A structure storing additional outcome information. When Outcome is collision-related, the collisions
+     * will be stored. When it is JOINT_LIMIT, the joint indices will be stored.
+     */
+    struct OutcomeInformation
+    {
+      std::vector<std::pair<std::string, std::string>> collisions;
+      std::vector<unsigned> joint_indices;
+
+      static OutcomeInformation CollisionInformation(std::vector<std::pair<std::string, std::string>> collisions);
+      static OutcomeInformation JointNumbers(std::vector<unsigned> joint_indices);
+    };
+
     /* The trajectory steps from start to termination. */
     std::vector<rl::math::Vector> trajectory;
 
-    /* Set of outcomes.
-     * It is either one positive outcome: REACHED or ACCEPTABLE_COLLISION,
-     * or a set of negative outcomes, that led to the termination of the planner.
+    /* A map of outcomes.
+     * It contains either only one positive outcome: REACHED or ACCEPTABLE_COLLISION,
+     * or one or more negative outcomes, that led to the termination of the planner. The outcomes
+     * are mapped to additional outcome information.
      */
-    std::set<Outcome> outcomes;
+    std::unordered_map<Outcome, OutcomeInformation> outcomes;
 
     /* SingleResult converts to true when the termination was successful and
      * false otherwise.
      */
     operator bool() const;
 
-    /* Put one outcome in outcomes and return self. */
-    SingleResult& setSingleOutcome(Outcome outcome);
+    /* Clear outcomes and put one outcome with information there and return self. */
+    SingleResult& setSingleOutcome(Outcome outcome, OutcomeInformation outcome_information = OutcomeInformation());
 
-    /* Textual description of the result. Lists all outcomes in a string. */
-    std::string description() const;
+    /* Add one outcome with information in outcomes and return self. */
+    SingleResult& addSingleOutcome(Outcome outcome, OutcomeInformation outcome_information = OutcomeInformation());
   };
 
   /* Represents the result of moveBelief. */
@@ -126,7 +139,8 @@ private:
   typedef std::vector<std::pair<std::string, std::string>> CollisionPairs;
   struct CollisionConstraintsCheck
   {
-    std::set<SingleResult::Outcome> failures;
+    std::unordered_map<SingleResult::Outcome, SingleResult::OutcomeInformation> failures;
+    std::vector<std::pair<std::string, std::string>> seen_terminating_collisions;
     std::set<std::string> seen_required_world_collisions;
     bool success_termination = false;
   };
@@ -162,8 +176,8 @@ private:
 
   std::mt19937 random_engine_;
 
-// TODO find a way to remove QT signals and slots so this class does not use QT but still is able to
-// visualize the execution in viewer.
+  // TODO find a way to remove QT signals and slots so this class does not use QT but still is able to
+  // visualize the execution in viewer.
 signals:
   void applyFunctionToScene(std::function<void(rl::sg::Scene&)> function);
   void reset();


### PR DESCRIPTION
This PR implements providing additional information in the output of /check_kinematics service. 

When the joint limit is violated, it will be the indices of joints that have crossed the joint limit. When the reason for termination is collision-related (prohibited collision, unsensorized collision, successful terminating collision or missing required collisions), it will be the respective collisions causing termination.